### PR TITLE
Add BuiltWithDot.Net badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ ReferenceResolver | [![ReferenceResolver](https://img.shields.io/nuget/v/Referen
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/weihanli/dotnet-exec)](https://hub.docker.com/r/weihanli/dotnet-exec)
 
+[![BuiltWithDot.Net shield](https://builtwithdot.net/project/5741/dotnet-exec/badge)](https://builtwithdot.net/project/5741/dotnet-exec)
+
 [中文介绍](./README.zh-CN.md)
 
 ## Intro


### PR DESCRIPTION
Since dotnet-exec is listed on BuiltWithDot.Net I've taken the liberty to raise a PR that adds the BuiltWithDot.Net badge for dotnet-exec to the README.md file. This will help promote your project, BuiltWithDot.Net, all other .NET developers that have projects listed on the site, and the open-source .NET ecosystem in general. If you have any questions or concerns, please let me know. Your help is much appreciated!

Thanks, Corstiaan (creator of BuiltWithDot.Net)

PS If you don't want to add the badge, that's totally fine. Just close this PR. No hard feelings :-)