### PR TITLE
Enhance REPL with multi-line input

### DIFF
--- a/src/dotnet-exec/Services/Repl.cs
+++ b/src/dotnet-exec/Services/Repl.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Weihan Li. All rights reserved.
+﻿// Copyright (c) 2022-2024 Weihan Li. All rights reserved.
 // Licensed under the Apache license version 2.0 http://www.apache.org/licenses/LICENSE-2.0
 
 using Microsoft.CodeAnalysis;

--- a/src/dotnet-exec/Services/Repl.cs
+++ b/src/dotnet-exec/Services/Repl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022-2024 Weihan Li. All rights reserved.
+// Copyright (c) 2022-2024 Weihan Li. All rights reserved.
 // Licensed under the Apache license version 2.0 http://www.apache.org/licenses/LICENSE-2.0
 
 using Microsoft.CodeAnalysis;
@@ -44,6 +44,7 @@ internal sealed class Repl
                 #r to reference dll or package, for example: "#r nuget:CsvHelper", "#r nuget: CsvHelper, 30.0.0", "#r /a/b/c.dll"
             """);
         ScriptState? state = null;
+        var inputBuilder = new StringBuilder();
         while (true)
         {
             Console.Write("> ");
@@ -110,15 +111,25 @@ internal sealed class Repl
                 continue;
             }
 
+            inputBuilder.AppendLine(input);
+
+            if (input.EndsWith(" \"))
+            {
+                continue;
+            }
+
+            var finalInput = inputBuilder.ToString();
+            inputBuilder.Clear();
+
             try
             {
                 if (state is null)
                 {
-                    state = await CSharpScript.RunAsync(input, scriptOptions);
+                    state = await CSharpScript.RunAsync(finalInput, scriptOptions);
                 }
                 else
                 {
-                    var anotherScriptState = await state.ContinueWithAsync(input, scriptOptions);
+                    var anotherScriptState = await state.ContinueWithAsync(finalInput, scriptOptions);
                     state = anotherScriptState;
                 }
                 if (state.ReturnValue is not null)

--- a/src/dotnet-exec/Services/Repl.cs
+++ b/src/dotnet-exec/Services/Repl.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Scripting;
 using ReferenceResolver;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Text;
 
 namespace Exec.Services;
 
@@ -113,7 +114,7 @@ internal sealed class Repl
 
             inputBuilder.AppendLine(input);
 
-            if (input.EndsWith(" \"))
+            if (input.EndsWith(" \\", StringComparison.Ordinal))
             {
                 continue;
             }

--- a/src/dotnet-exec/Services/Repl.cs
+++ b/src/dotnet-exec/Services/Repl.cs
@@ -46,9 +46,16 @@ internal sealed class Repl
             """);
         ScriptState? state = null;
         var inputBuilder = new StringBuilder();
-        while (true)
+        while (!ApplicationHelper.ExitToken.IsCancellationRequested)
         {
-            Console.Write("> ");
+            if (inputBuilder.Length > 0)
+            {
+                Console.Write("* ");
+            }
+            else
+            {
+                Console.Write("> ");
+            }
             var input = Console.ReadLine();
 
             if (string.IsNullOrWhiteSpace(input))
@@ -112,13 +119,13 @@ internal sealed class Repl
                 continue;
             }
 
-            inputBuilder.AppendLine(input);
-
             if (input.EndsWith(" \\", StringComparison.Ordinal))
             {
+                inputBuilder.Append(input[..^2]);
                 continue;
             }
 
+            inputBuilder.Append(input);
             var finalInput = inputBuilder.ToString();
             inputBuilder.Clear();
 


### PR DESCRIPTION
Related to #25

Enhance REPL to support multi-line input

* Add a `StringBuilder` to accumulate multi-line input.
* Append each line of input to the `StringBuilder`.
* Check for incomplete statements and allow continuation by checking if the input ends with " \\".
* Clear the `StringBuilder` after processing the final input.
* Update the script execution to use the accumulated input from the `StringBuilder`.
