### PR TITLE
Add xunit test case execution support

### DIFF
--- a/docs/articles/en/getting-started.md
+++ b/docs/articles/en/getting-started.md
@@ -142,3 +142,13 @@ and some preview features annotated with `RequiresPreviewFeaturesAttribute` coul
 ### Profile command
 
 Profile commands could configure custom config profile to simplify options configuration when executing
+
+### Test command
+
+The `test` command allows you to execute xunit test cases.
+
+```sh
+dotnet-exec test XxTest.cs
+```
+
+This command integrates with the xunit v3 to execute the specified xunit test file.

--- a/docs/articles/zh/getting-started.md
+++ b/docs/articles/zh/getting-started.md
@@ -133,3 +133,13 @@ dotnet-exec 'WebApplication.Create().Run();' --reference 'framework:web'
 ### Profile command
 
 Profile 命令可以用来配置一些自定义的 profile 来简化执行时要指定的选项
+
+### Test command
+
+`test` 命令允许你执行 xunit 测试用例。
+
+```sh
+dotnet-exec test XxTest.cs
+```
+
+此命令集成了 xunit v3 以执行指定的 xunit 测试文件。

--- a/src/dotnet-exec/Commands/ConfigProfileCommand.cs
+++ b/src/dotnet-exec/Commands/ConfigProfileCommand.cs
@@ -3,7 +3,7 @@
 
 namespace Exec.Commands;
 
-public sealed class ConfigProfileCommand : Command
+internal sealed class ConfigProfileCommand : Command
 {
     public ConfigProfileCommand() : base("profile", "Configure user config profile")
     {

--- a/src/dotnet-exec/Commands/TestCommand.cs
+++ b/src/dotnet-exec/Commands/TestCommand.cs
@@ -10,7 +10,7 @@ internal sealed class TestCommand : Command
     private readonly Argument<string[]> _testFileArgument = new
     (
         "testFiles",
-        "The xunit test file to execute"
+        "The xunit test files to test"
     )
     {
         Arity = ArgumentArity.OneOrMore

--- a/src/dotnet-exec/Commands/TestCommand.cs
+++ b/src/dotnet-exec/Commands/TestCommand.cs
@@ -1,21 +1,62 @@
-using System.CommandLine;
-using System.CommandLine.Invocation;
-using Xunit.ConsoleClient;
+// Copyright (c) 2022-2024 Weihan Li. All rights reserved.
+// Licensed under the Apache license version 2.0 http://www.apache.org/licenses/LICENSE-2.0
 
 namespace Exec.Commands;
 
 internal sealed class TestCommand : Command
 {
+    private const string XunitTestEntryCode = "await Xunit.Runner.InProc.SystemConsole.ConsoleRunner.Run(args);";
+    
+    private readonly Argument<string[]> _testFileArgument = new
+    (
+        "testFiles",
+        "The xunit test file to execute"
+    )
+    {
+        Arity = ArgumentArity.OneOrMore
+    };
+    
     public TestCommand() : base("test", "Execute xunit test cases")
     {
-        var testFileArgument = new Argument<string>("testFile", "The xunit test file to execute");
-        AddArgument(testFileArgument);
+        AddArgument(_testFileArgument);
+        
+        AddOption(ExecOptions.UsingsOption);
+        AddOption(ExecOptions.ReferencesOption);
+        AddOption(ExecOptions.WebReferencesOption);
+        AddOption(ExecOptions.WideReferencesOption);
+        AddOption(ExecOptions.PreviewOption);
+    }
 
-        this.Handler = CommandHandler.Create<string>(async (testFile) =>
+    public async Task<int> InvokeAsync(InvocationContext context, CommandHandler commandHandler)
+    {
+        var testFiles = context.ParseResult.GetValueForArgument(_testFileArgument);
+        
+        var options = new ExecOptions
         {
-            var consoleRunner = new ConsoleRunner();
-            var result = await consoleRunner.RunAsync(new[] { testFile });
-            return result;
-        });
+            Script = XunitTestEntryCode,
+            AdditionalScripts = [..testFiles],
+            References = ["nuget: xunit.v3,2.0.0"],
+            Usings = ["global::Xunit", "global::Xunit.v3"],
+            CompilerType = Helper.Project,
+            ExecutorType = Helper.Project,
+            CancellationToken = context.GetCancellationToken()
+        };
+        
+        var references = context.ParseResult.GetValueForOption(ExecOptions.ReferencesOption);
+        foreach (var reference in references ?? [])
+        {
+            options.References.Add(reference);
+        }
+        var usings = context.ParseResult.GetValueForOption(ExecOptions.UsingsOption);
+        foreach (var @using in usings ?? [])
+        {
+            options.Usings.Add(@using);
+        }
+        
+        options.IncludeWebReferences = context.ParseResult.GetValueForOption(ExecOptions.WebReferencesOption);
+        options.EnablePreviewFeatures = context.ParseResult.GetValueForOption(ExecOptions.PreviewOption);
+        options.IncludeWideReferences = false;
+
+        return await commandHandler.Execute(options);
     }
 }

--- a/src/dotnet-exec/Commands/TestCommand.cs
+++ b/src/dotnet-exec/Commands/TestCommand.cs
@@ -1,0 +1,21 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using Xunit.ConsoleClient;
+
+namespace Exec.Commands;
+
+internal sealed class TestCommand : Command
+{
+    public TestCommand() : base("test", "Execute xunit test cases")
+    {
+        var testFileArgument = new Argument<string>("testFile", "The xunit test file to execute");
+        AddArgument(testFileArgument);
+
+        this.Handler = CommandHandler.Create<string>(async (testFile) =>
+        {
+            var consoleRunner = new ConsoleRunner();
+            var result = await consoleRunner.RunAsync(new[] { testFile });
+            return result;
+        });
+    }
+}

--- a/src/dotnet-exec/ExecOptions.Command.cs
+++ b/src/dotnet-exec/ExecOptions.Command.cs
@@ -223,6 +223,7 @@ public sealed partial class ExecOptions
         // add sub commands
         command.AddCommand(new ConfigProfileCommand());
         command.AddCommand(new AliasCommand());
+        command.AddCommand(new TestCommand());
 
         return command;
     }

--- a/src/dotnet-exec/Helper.cs
+++ b/src/dotnet-exec/Helper.cs
@@ -146,14 +146,14 @@ public static class Helper
     public static void Initialize(this Command command, IServiceProvider serviceProvider)
     {
         ArgumentNullException.ThrowIfNull(command);
-        command.Handler = serviceProvider.GetRequiredService<ICommandHandler>();
+        var commandHandler = serviceProvider.GetRequiredService<CommandHandler>();
+        command.Handler = commandHandler;
         var profileManager = serviceProvider.GetRequiredService<IConfigProfileManager>();
         var appConfiguration = serviceProvider.GetRequiredService<AppConfiguration>();
         var appConfigSource = serviceProvider.GetRequiredService<IAppConfigSource>();
 
         foreach (var subcommand in command.Subcommands)
         {
-
             switch (subcommand)
             {
                 case ConfigProfileCommand configProfileCommand:
@@ -272,8 +272,11 @@ public static class Helper
                         aliasSubCommand.SetHandler(aliasCommandHandler);
                     }
                     break;
+                
+                case TestCommand testCommand:
+                    testCommand.SetHandler(context => testCommand.InvokeAsync(context, commandHandler));
+                    break;
             }
-
         }
     }
 

--- a/src/dotnet-exec/Properties/launchSettings.json
+++ b/src/dotnet-exec/Properties/launchSettings.json
@@ -89,6 +89,11 @@
       "commandName": "Project",
       "targetFramework": "net10.0",
       "commandLineArgs": "\"Console.WriteLine(1 + 1);\" --compiler project --debug"
+    },
+    "xunit-test": {
+      "commandName": "Project",
+      "targetFramework": "net10.0",
+      "commandLineArgs": "test \"public class Tests{ [Fact] public void Test1(){ Assert.Equal(3, 1 + 2); } }\""
     }
   }
 }

--- a/src/dotnet-exec/dotnet-exec.csproj
+++ b/src/dotnet-exec/dotnet-exec.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="UnitTest" />
+    <InternalsVisibleTo Include="IntegrationTest" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ReferenceResolver\ReferenceResolver.csproj" />

--- a/tests/IntegrationTest/CodeSamples/XunitSample.cs
+++ b/tests/IntegrationTest/CodeSamples/XunitSample.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) 2022-2024 Weihan Li. All rights reserved.
+// Licensed under the Apache license version 2.0 http://www.apache.org/licenses/LICENSE-2.0
+
+namespace IntegrationTest.CodeSamples;
+
+public class XunitSample
+{
+    [Fact]
+    public void AddTest()
+    {
+        Assert.Equal(3, Add(1, 2));
+    }
+    
+    [Theory]
+    [InlineData(1, 2, 3)]
+    public void AddTestByTheory(int a, int b, int expected)
+    {
+        Assert.Equal(expected, Add(a, b));
+    }
+    
+    private static int Add(int a, int b) => a + b;
+}

--- a/tests/IntegrationTest/ConfigProfileManagerTests.cs
+++ b/tests/IntegrationTest/ConfigProfileManagerTests.cs
@@ -7,8 +7,6 @@ namespace IntegrationTest;
 
 public class ConfigProfileManagerTests(IConfigProfileManager configProfileManager)
 {
-    private readonly IConfigProfileManager _configProfileManager = configProfileManager;
-
     [Fact]
     public async Task ProfileOperation()
     {
@@ -18,22 +16,22 @@ public class ConfigProfileManagerTests(IConfigProfileManager configProfileManage
             EntryPoint = "Execute"
         };
         var name = Guid.NewGuid().ToString();
-        var getProfile = await _configProfileManager.GetProfile(name);
+        var getProfile = await configProfileManager.GetProfile(name);
         Assert.Null(getProfile);
         try
         {
-            await _configProfileManager.ConfigureProfile(name, profile);
-            getProfile = await _configProfileManager.GetProfile(name);
+            await configProfileManager.ConfigureProfile(name, profile);
+            getProfile = await configProfileManager.GetProfile(name);
             Assert.NotNull(getProfile);
             Assert.Equal(profile.IncludeWideReferences, getProfile.IncludeWideReferences);
             Assert.Equal(profile.EntryPoint, getProfile.EntryPoint);
 
-            var profiles = await _configProfileManager.ListProfiles();
+            var profiles = await configProfileManager.ListProfiles();
             Assert.NotEmpty(profiles);
         }
         finally
         {
-            await _configProfileManager.DeleteProfile(name);
+            await configProfileManager.DeleteProfile(name);
         }
     }
 }

--- a/tests/IntegrationTest/IntegrationTests.cs
+++ b/tests/IntegrationTest/IntegrationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2022-2024 Weihan Li. All rights reserved.
 // Licensed under the Apache license version 2.0 http://www.apache.org/licenses/LICENSE-2.0
 
+using Exec.Commands;
 using WeihanLi.Common.Models;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
@@ -644,6 +645,24 @@ public class IntegrationTests(
         Assert.Equal(0, result);
 
         outputHelper.WriteLine(output.StandardOutput);
+    }
+    
+    [Theory]
+    [InlineData("XunitSample")]
+    public async Task TestCommandExecuteTest(string sampleName)
+    {
+        var filePath = $"{sampleName}.cs";
+        var fullPath = Path.Combine(Directory.GetCurrentDirectory(), "CodeSamples", filePath);
+        Assert.True(File.Exists(fullPath));
+
+        var execOptions = new ExecOptions()
+        {
+            IncludeWebReferences = false,
+            IncludeWideReferences = false,
+        };
+
+        var result = await TestCommand.ExecuteAsync(handler, execOptions, fullPath);
+        Assert.Equal(0, result);
     }
 
     public static IEnumerable<TheoryDataRow<int, string>> EntryMethodWithExitCodeTestData()

--- a/tests/IntegrationTest/IntegrationTests.cs
+++ b/tests/IntegrationTest/IntegrationTests.cs
@@ -12,7 +12,7 @@ public class IntegrationTests(
     ICompilerFactory compilerFactory,
     IExecutorFactory executorFactory,
     ITestOutputHelper outputHelper
-        )
+    )
 {
     [Theory]
     [InlineData("ConfigurationManagerSample")]
@@ -50,11 +50,8 @@ public class IntegrationTests(
             EnablePreviewFeatures = true
         };
 
-        using var output = await ConsoleOutput.CaptureAsync();
         var result = await handler.Execute(execOptions);
         Assert.Equal(0, result);
-
-        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory]
@@ -93,11 +90,8 @@ public class IntegrationTests(
             EnablePreviewFeatures = true
         };
 
-        using var output = await ConsoleOutput.CaptureAsync();
         var result = await handler.Execute(execOptions);
         Assert.Equal(0, result);
-
-        outputHelper.WriteLine(output.StandardOutput);
     }
     
     [Theory]
@@ -132,11 +126,8 @@ public class IntegrationTests(
             EnablePreviewFeatures = true
         };
 
-        using var output = await ConsoleOutput.CaptureAsync();
         var result = await handler.Execute(execOptions);
         Assert.Equal(0, result);
-
-        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory]
@@ -157,11 +148,8 @@ public class IntegrationTests(
             ExecutorType = "project"
         };
 
-        using var output = await ConsoleOutput.CaptureAsync();
         var result = await handler.Execute(execOptions);
         Assert.Equal(0, result);
-
-        outputHelper.WriteLine(output.StandardOutput);
     }
     
     [Theory]
@@ -172,10 +160,8 @@ public class IntegrationTests(
     [InlineData("https://gist.githubusercontent.com/WeihanLi/7b4032a32f1a25c5f2d84b6955fa83f3/raw/3e10a606b4121e0b7babcdf68a8fb1203c93c81c/print-date.cs")]
     public async Task RemoteScriptExecute(string fileUrl)
     {
-        using var output = await ConsoleOutput.CaptureAsync();
-        var result = await handler.Execute(new ExecOptions() { Script = fileUrl });
+        var result = await handler.Execute(new ExecOptions { Script = fileUrl });
         Assert.Equal(0, result);
-        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory]

--- a/tests/IntegrationTest/IntegrationTests.cs
+++ b/tests/IntegrationTest/IntegrationTests.cs
@@ -14,11 +14,6 @@ public class IntegrationTests(
     ITestOutputHelper outputHelper
         )
 {
-    private readonly CommandHandler _handler = handler;
-    private readonly ICompilerFactory _compilerFactory = compilerFactory;
-    private readonly IExecutorFactory _executorFactory = executorFactory;
-    private readonly ITestOutputHelper _outputHelper = outputHelper;
-
     [Theory]
     [InlineData("ConfigurationManagerSample")]
     [InlineData("JsonNodeSample")]
@@ -56,10 +51,10 @@ public class IntegrationTests(
         };
 
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(execOptions);
+        var result = await handler.Execute(execOptions);
         Assert.Equal(0, result);
 
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory]
@@ -99,10 +94,10 @@ public class IntegrationTests(
         };
 
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(execOptions);
+        var result = await handler.Execute(execOptions);
         Assert.Equal(0, result);
 
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
     
     [Theory]
@@ -138,10 +133,10 @@ public class IntegrationTests(
         };
 
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(execOptions);
+        var result = await handler.Execute(execOptions);
         Assert.Equal(0, result);
 
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory]
@@ -163,10 +158,10 @@ public class IntegrationTests(
         };
 
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(execOptions);
+        var result = await handler.Execute(execOptions);
         Assert.Equal(0, result);
 
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
     
     [Theory]
@@ -178,9 +173,9 @@ public class IntegrationTests(
     public async Task RemoteScriptExecute(string fileUrl)
     {
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(new ExecOptions() { Script = fileUrl });
+        var result = await handler.Execute(new ExecOptions() { Script = fileUrl });
         Assert.Equal(0, result);
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory]
@@ -203,10 +198,10 @@ public class IntegrationTests(
         };
 
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(execOptions);
+        var result = await handler.Execute(execOptions);
         Assert.Equal(0, result);
 
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory]
@@ -216,9 +211,9 @@ public class IntegrationTests(
     public async Task CodeTextExecute(string code)
     {
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(new ExecOptions() { Script = code });
+        var result = await handler.Execute(new ExecOptions() { Script = code });
         Assert.Equal(0, result);
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory]
@@ -226,9 +221,9 @@ public class IntegrationTests(
     public async Task ImplicitScriptTextExecute(string code)
     {
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(new ExecOptions() { Script = code });
+        var result = await handler.Execute(new ExecOptions() { Script = code });
         Assert.Equal(0, result);
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory]
@@ -238,35 +233,35 @@ public class IntegrationTests(
     public async Task ScriptTextExecute(string code)
     {
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(new ExecOptions() { Script = code });
+        var result = await handler.Execute(new ExecOptions() { Script = code });
         Assert.Equal(0, result);
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Fact]
     public async Task ScriptStaticUsingTest()
     {
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(new ExecOptions()
+        var result = await handler.Execute(new ExecOptions()
         {
             Script = "WriteLine(Math.PI)",
             Usings = ["static System.Console"]
         });
         Assert.Equal(0, result);
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Fact]
     public async Task ScriptUsingAliasTest()
     {
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(new ExecOptions()
+        var result = await handler.Execute(new ExecOptions()
         {
             Script = "MyConsole.WriteLine(Math.PI)",
             Usings = ["MyConsole = System.Console"]
         });
         Assert.Equal(0, result);
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory]
@@ -275,19 +270,19 @@ public class IntegrationTests(
     public async Task AssemblyLoadContextExecutorTest(string code)
     {
         var options = new ExecOptions();
-        var compiler = _compilerFactory.GetCompiler(options.CompilerType);
+        var compiler = compilerFactory.GetCompiler(options.CompilerType);
         var result = await compiler.Compile(options, code);
         if (result.Msg.IsNotNullOrEmpty())
-            _outputHelper.WriteLine(result.Msg);
+            outputHelper.WriteLine(result.Msg);
         Assert.True(result.IsSuccess());
         Assert.NotNull(result.Data);
         using var output = await ConsoleOutput.CaptureAsync();
-        var executor = _executorFactory.GetExecutor(options.ExecutorType);
+        var executor = executorFactory.GetExecutor(options.ExecutorType);
         var executeResult = await executor.Execute(Guard.NotNull(result.Data), options);
         if (executeResult.Msg.IsNotNullOrEmpty())
-            _outputHelper.WriteLine(executeResult.Msg);
+            outputHelper.WriteLine(executeResult.Msg);
         Assert.True(executeResult.IsSuccess());
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Fact]
@@ -299,7 +294,7 @@ public class IntegrationTests(
             Usings = ["WeihanLi.Npoi"],
             Script = "CsvHelper.GetCsvText(new[]{1,2,3}).Dump();"
         };
-        var result = await _handler.Execute(options);
+        var result = await handler.Execute(options);
         Assert.Equal(0, result);
     }
 
@@ -317,11 +312,11 @@ public class IntegrationTests(
             Usings = ["WeihanLi.Npoi"],
             Script = "CsvHelper.GetCsvText(new[]{1,2,3}).Dump()"
         };
-        var result = await _handler.Execute(options);
+        var result = await handler.Execute(options);
         Assert.Equal(0, result);
         Assert.NotNull(output.StandardOutput);
         Assert.NotEmpty(output.StandardOutput);
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory(
@@ -338,11 +333,11 @@ public class IntegrationTests(
             Usings = ["WeihanLi.Npoi"],
             Script = "CsvHelper.GetCsvText(new[]{1,2,3}).Dump()"
         };
-        var result = await _handler.Execute(options);
+        var result = await handler.Execute(options);
         Assert.Equal(0, result);
         Assert.NotNull(output.StandardOutput);
         Assert.NotEmpty(output.StandardOutput);
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
 
@@ -360,11 +355,11 @@ public class IntegrationTests(
             Usings = ["WeihanLi.Npoi"],
             Script = "CsvHelper.GetCsvText(new[]{1,2,3}).Dump()"
         };
-        var result = await _handler.Execute(options);
+        var result = await handler.Execute(options);
         Assert.Equal(0, result);
         Assert.NotNull(output.StandardOutput);
         Assert.NotEmpty(output.StandardOutput);
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory]
@@ -377,7 +372,7 @@ public class IntegrationTests(
             ProjectPath = projectPath,
             Script = "System.Console.WriteLine(MyFile.Exists(\"appsettings.json\"));"
         };
-        var result = await _handler.Execute(options);
+        var result = await handler.Execute(options);
         Assert.Equal(0, result);
     }
 
@@ -403,7 +398,7 @@ public class IntegrationTests(
             Script = fullPath,
             CompilerType = "simple"
         };
-        var result = await _handler.Execute(options);
+        var result = await handler.Execute(options);
         Assert.Equal(0, result);
     }
 
@@ -419,8 +414,8 @@ public class IntegrationTests(
             Script = "Console.Write(typeof(System.Text.Json.JsonSerializer).Assembly.GetName().Version.ToString(2));"
         };
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(options);
-        _outputHelper.WriteLine(output.StandardOutput);
+        var result = await handler.Execute(options);
+        outputHelper.WriteLine(output.StandardOutput);
         Assert.Equal(0, result);
         // Assert.Equal(version, output.StandardOutput);
     }
@@ -433,7 +428,7 @@ public class IntegrationTests(
         {
             Script = code
         };
-        var result = await _handler.Execute(options);
+        var result = await handler.Execute(options);
         Assert.Equal(expectedExitCode, result);
     }
 
@@ -447,8 +442,8 @@ public class IntegrationTests(
         var result = await CommandExecutor.ExecuteAndCaptureAsync(
             exePath, $"\"Environment.ExitCode = {exitCode};\"", cancellationToken: TestContext.Current.CancellationToken
             );
-        _outputHelper.WriteLine(result.StandardOut);
-        _outputHelper.WriteLine(result.StandardError);
+        outputHelper.WriteLine(result.StandardOut);
+        outputHelper.WriteLine(result.StandardError);
         Assert.Equal(exitCode, result.ExitCode);
     }
 
@@ -477,10 +472,10 @@ public class IntegrationTests(
         };
 
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(execOptions);
+        var result = await handler.Execute(execOptions);
         Assert.Equal(0, result);
 
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory(
@@ -508,10 +503,10 @@ public class IntegrationTests(
         };
 
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(execOptions);
+        var result = await handler.Execute(execOptions);
         Assert.Equal(0, result);
 
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory]
@@ -534,10 +529,10 @@ public class IntegrationTests(
         };
 
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(execOptions);
+        var result = await handler.Execute(execOptions);
         Assert.Equal(0, result);
 
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory]
@@ -558,10 +553,10 @@ public class IntegrationTests(
         };
 
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(execOptions);
+        var result = await handler.Execute(execOptions);
         Assert.NotEqual(0, result);
 
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Fact]
@@ -579,7 +574,7 @@ public class IntegrationTests(
             Script = code,
             DryRun = true,
         };
-        await _handler.Execute(options);
+        await handler.Execute(options);
         Assert.Single(options.References);
     }
 
@@ -597,7 +592,7 @@ public class IntegrationTests(
             DryRun = true,
             References = ["-nuget: WeihanLi.Common, 1.0.64"]
         };
-        await _handler.Execute(options);
+        await handler.Execute(options);
         Assert.Empty(options.References);
     }
 
@@ -615,7 +610,7 @@ public class IntegrationTests(
             DryRun = true,
             References = ["- nuget: WeihanLi.Common"]
         };
-        await _handler.Execute(options);
+        await handler.Execute(options);
         Assert.Empty(options.References);
     }
 
@@ -637,10 +632,10 @@ public class IntegrationTests(
         };
 
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(execOptions);
+        var result = await handler.Execute(execOptions);
         Assert.Equal(0, result);
 
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     [Theory]
@@ -659,10 +654,10 @@ public class IntegrationTests(
         };
 
         using var output = await ConsoleOutput.CaptureAsync();
-        var result = await _handler.Execute(execOptions);
+        var result = await handler.Execute(execOptions);
         Assert.Equal(0, result);
 
-        _outputHelper.WriteLine(output.StandardOutput);
+        outputHelper.WriteLine(output.StandardOutput);
     }
 
     public static IEnumerable<TheoryDataRow<int, string>> EntryMethodWithExitCodeTestData()

--- a/tests/IntegrationTest/IntegrationTests.cs
+++ b/tests/IntegrationTest/IntegrationTests.cs
@@ -645,7 +645,7 @@ public class IntegrationTests(
 
     [Theory]
     [InlineData("NetpadExecSample")]
-    public async Task NetpadExecTest(string sampleName)
+    public async Task NetPadExecTest(string sampleName)
     {
         var filePath = $"{sampleName}.netpad";
         var fullPath = Path.Combine(Directory.GetCurrentDirectory(), "CodeSamples", filePath);
@@ -665,17 +665,17 @@ public class IntegrationTests(
         _outputHelper.WriteLine(output.StandardOutput);
     }
 
-    public static IEnumerable<object[]> EntryMethodWithExitCodeTestData()
+    public static IEnumerable<TheoryDataRow<int, string>> EntryMethodWithExitCodeTestData()
     {
-        yield return [0, @"Console.WriteLine(""Amazing dotnet"");"];
+        yield return new TheoryDataRow<int, string>(0, """Console.WriteLine("Amazing dotnet");""");
 
-        yield return [0, "return 0;"];
-        yield return [1, "return 1;"];
+        yield return new TheoryDataRow<int, string>(0, "return 0;");
+        yield return new TheoryDataRow<int, string>(1, "return 1;");
 
-        yield return [0, "return await Task.FromResult(0);"];
-        yield return [1, "return await Task.FromResult(1);"];
+        yield return new TheoryDataRow<int, string>(0, "return await Task.FromResult(0);");
+        yield return new TheoryDataRow<int, string>(1, "return await Task.FromResult(1);");
 
-        yield return [0, "return await ValueTask.FromResult(0);"];
-        yield return [1, "return await ValueTask.FromResult(1);"];
+        yield return new TheoryDataRow<int, string>(0, "return await ValueTask.FromResult(0);");
+        yield return new TheoryDataRow<int, string>(1, "return await ValueTask.FromResult(1);");
     }
 }

--- a/tests/UnitTest/CodeExecutorTest.cs
+++ b/tests/UnitTest/CodeExecutorTest.cs
@@ -9,7 +9,6 @@ namespace UnitTest;
 
 public sealed class CodeExecutorTest(ITestOutputHelper outputHelper)
 {
-    private readonly ITestOutputHelper _outputHelper = outputHelper;
     private readonly SimpleCodeCompiler _compiler = SimpleCodeCompilerTest.GetSimpleCodeCompiler();
 
     [Theory]
@@ -22,13 +21,13 @@ public sealed class CodeExecutorTest(ITestOutputHelper outputHelper)
             Arguments = ["--hello", "world"]
         };
         var result = await _compiler.Compile(execOptions, code);
-        _outputHelper.WriteLine($"{result.Msg}");
+        outputHelper.WriteLine($"{result.Msg}");
         Assert.True(result.IsSuccess());
         Assert.NotNull(result.Data);
         Guard.NotNull(result.Data);
         var executor = new DefaultCodeExecutor(RefResolver.InstanceForTest, NullLogger.Instance);
         var executeResult = await executor.Execute(result.Data, execOptions);
-        _outputHelper.WriteLine($"{executeResult.Msg}");
+        outputHelper.WriteLine($"{executeResult.Msg}");
         Assert.True(executeResult.IsSuccess());
     }
 
@@ -62,7 +61,7 @@ internal class SomeTest
         Guard.NotNull(result.Data);
         var executor = new DefaultCodeExecutor(RefResolver.InstanceForTest, NullLogger.Instance);
         var executeResult = await executor.Execute(result.Data, execOptions);
-        _outputHelper.WriteLine($"{executeResult.Msg}");
+        outputHelper.WriteLine($"{executeResult.Msg}");
         Assert.True(executeResult.IsSuccess());
     }
 
@@ -114,7 +113,7 @@ class B
         var executor = new DefaultCodeExecutor(RefResolver.InstanceForTest, NullLogger.Instance);
         var executeResult = await executor.Execute(result.Data, options);
         Assert.NotNull(executeResult.Msg);
-        _outputHelper.WriteLine(executeResult.Msg);
+        outputHelper.WriteLine(executeResult.Msg);
         Assert.False(executeResult.IsSuccess());
     }
 }

--- a/tests/UnitTest/SimpleCodeCompilerTest.cs
+++ b/tests/UnitTest/SimpleCodeCompilerTest.cs
@@ -8,8 +8,6 @@ namespace UnitTest;
 
 public sealed class SimpleCodeCompilerTest(ITestOutputHelper outputHelper)
 {
-    private readonly ITestOutputHelper _outputHelper = outputHelper;
-
     [Theory]
     [InlineData(@"public static void Main(int num){}")]
     [InlineData(@"public class Program{ public static int Main(){} }")]
@@ -19,7 +17,7 @@ public sealed class SimpleCodeCompilerTest(ITestOutputHelper outputHelper)
         var result = await compiler.Compile(new ExecOptions(), code);
         Assert.Equal(ResultStatus.InternalError, result.Status);
         Assert.NotNull(result.Msg);
-        _outputHelper.WriteLine(result.Msg);
+        outputHelper.WriteLine(result.Msg);
     }
 
     [Theory]
@@ -36,7 +34,7 @@ Console.WriteLine(args.StringJoin(Environment.NewLine));
     {
         var compiler = GetSimpleCodeCompiler();
         var result = await compiler.Compile(new ExecOptions(), code);
-        _outputHelper.WriteLine($"{result.Msg}");
+        outputHelper.WriteLine($"{result.Msg}");
         Assert.Equal(ResultStatus.Success, result.Status);
     }
 
@@ -68,7 +66,7 @@ Console.WriteLine("""
         {
             EnablePreviewFeatures = true
         }, code);
-        _outputHelper.WriteLine($"{result.Msg}");
+        outputHelper.WriteLine($"{result.Msg}");
         Assert.Equal(ResultStatus.Success, result.Status);
     }
 


### PR DESCRIPTION

feat: Add support for executing xunit test cases with the `dotnet-exec test` command.

* **New Command**: Add `TestCommand.cs` to handle xunit test case execution.
* **Documentation**: Update `getting-started.md` in both English and Chinese to include instructions for the new `test` command.

fixes #10 

